### PR TITLE
Search: case-insensitive excerpt matching

### DIFF
--- a/app/components/layout/Search.tsx
+++ b/app/components/layout/Search.tsx
@@ -15,13 +15,17 @@ import {
 function showExcerpt(body: string | null, query: string) {
 	if (body === null) return '...'
 
-	if (!body.includes(query)) return `${body}...`
+	const startIndex = body.toLowerCase().indexOf(query.toLowerCase())
+	if (startIndex === -1) return `${body}...`
 
-	const [before, after] = body.split(query)
+	const endIndex = startIndex + query.length
+	const before = body.slice(0, startIndex)
+	const matched = body.slice(startIndex, endIndex)
+	const after = body.slice(endIndex)
 	return (
 		<>
 			...{before}
-			<strong>{query}</strong>
+			<strong>{matched}</strong>
 			{after}...
 		</>
 	)

--- a/app/routes/documentation.$product.$ref.actions.search.tsx
+++ b/app/routes/documentation.$product.$ref.actions.search.tsx
@@ -7,6 +7,7 @@ function getBodyContext(body: string, term: string) {
 	const numContextWords = 2
 	const searchTermRegex = new RegExp(
 		`(?:\\s?(?:[\\w]+)\\s?){0,${numContextWords}}${term}(?:\\s?(?:[\\w]+)\\s?){0,${numContextWords}}`,
+		'i',
 	)
 	const excerptRegex = /^(\w+(?:\s+\w+){0,5})/
 

--- a/app/routes/documentation.private.$product.$ref.actions.search.tsx
+++ b/app/routes/documentation.private.$product.$ref.actions.search.tsx
@@ -7,6 +7,7 @@ function getBodyContext(body: string, term: string) {
 	const numContextWords = 2
 	const searchTermRegex = new RegExp(
 		`(?:\\s?(?:[\\w]+)\\s?){0,${numContextWords}}${term}(?:\\s?(?:[\\w]+)\\s?){0,${numContextWords}}`,
+		'i',
 	)
 	const excerptRegex = /^(\w+(?:\s+\w+){0,5})/
 


### PR DESCRIPTION
Before, excerpts varied, depending on query casing. For example, the excerpts for "olm" and "OLM" were not the same. This change uses case-insensitive methods to make excerpts consistent.

## Before
![image](https://github.com/CrunchyData/crunchy-docs/assets/20446836/bfe08d54-cdbf-46e0-abc6-1481ef9ce89b)

## After
![image](https://github.com/CrunchyData/crunchy-docs/assets/20446836/eb7ee037-a852-4161-aa31-053ccd71c096)
