### PR TITLE
Improving cache to only bust on change to SALT

### DIFF
--- a/app/utils/cache.server.ts
+++ b/app/utils/cache.server.ts
@@ -1,0 +1,14 @@
+import LRUCache from 'lru-cache'
+
+export let NO_CACHE = process.env.NO_CACHE ?? false
+export let SALT = process.env.CRUNCHY_CACHE_SALT ?? Date.now()
+
+export function createCache<T>(fetchMethod: LRUCache.Fetcher<string, T>) {
+	return new LRUCache<string, T>({
+		max: 1000,
+		ttl: NO_CACHE ? 1 : 1000 * 60 * 60 * 24 * 365, // 1 year
+		allowStale: !NO_CACHE,
+		noDeleteOnFetchRejection: true,
+		fetchMethod,
+	})
+}

--- a/app/utils/env.server.ts
+++ b/app/utils/env.server.ts
@@ -1,11 +1,16 @@
 import invariant from 'tiny-invariant'
 
 const requiredServerEnvs = ['NODE_ENV', 'SESSION_SECRET'] as const
+const allServerEnvs = [
+	...requiredServerEnvs,
+	'NO_CACHE',
+	'CRUNCHY_CACHE_SALT',
+] as const
 
 declare global {
 	namespace NodeJS {
 		interface ProcessEnv
-			extends Record<(typeof requiredServerEnvs)[number], string> {}
+			extends Record<(typeof allServerEnvs)[number], string> {}
 	}
 }
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build:server": "tsx ./scripts/build-server.ts",
     "dev": "run-p dev:*",
     "dev:remix": "remix dev -c \"npm run dev-server\" --no-restart",
-    "dev-server": "cross-env MOCKS=true tsx watch --clear-screen=false --ignore \"app/**\" --ignore \"docs-build/**\" --ignore \"node_modules/**\" ./index.js",
+    "dev-server": "cross-env MOCKS=true tsx watch --clear-screen=false --ignore \"app/**\" --ignore \"docs-build/**\" --ignore \"node_modules/**\" ./docs-index.js",
     "format": "prettier --write .",
     "lint": "eslint --cache --cache-location ./node_modules/.cache/eslint .",
     "lint:files": "ts-node --esm scripts/lint-file-case.ts",


### PR DESCRIPTION
Cache is now only busted by two methods:

1. Cache reaches max size (1000 records)
2. Cache SALT changes

There is now no time limit and the cache will bust on deploy where the `CRUNCHY_CACHE_SALT` env variable is auto incremented.