### PR TITLE
Change Node version format in `package.json`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -110,7 +110,7 @@
         "vfile-matter": "^4.0.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": "20"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/package.json
+++ b/package.json
@@ -136,6 +136,6 @@
     "vfile-matter": "^4.0.1"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": "20"
   }
 }


### PR DESCRIPTION
The format introduced in PR #6 is causing a build failure